### PR TITLE
Fix PlatformView null crash during async image loading

### DIFF
--- a/Maui.Nuke/ImageSourcesMauiAppBuilderExtensions.cs
+++ b/Maui.Nuke/ImageSourcesMauiAppBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Handlers;
 
 namespace Maui.Nuke;
@@ -19,10 +19,38 @@ public static class ImageSourcesMauiAppBuilderExtensions
 			handlers.AddHandler<Image, NukeImageHandler>();
 		});
 		
-		// Override the MapSource to use our custom implementation
+		// Override the MapSource to use our custom implementation with PlatformView null safety.
+		// 
+		// IMPORTANT: ViewHandler<T>.PlatformView throws InvalidOperationException when the
+		// native view is disconnected (e.g., during fast scrolling, navigation, tab switching).
+		// We guard against this at the mapper level as a defense-in-depth measure.
+		//
+		// See: https://github.com/dotnet/maui/issues/17165
+		//      https://github.com/dotnet/maui/issues/17569
+		//      https://github.com/roubachof/Maui.Nuke/issues/11
 		NukeImageHandler.Mapper.ModifyMapping(nameof(Microsoft.Maui.IImage.Source), (handler, view, _) =>
 		{
-			NukeImageHandler.MapSource(handler, view);
+			// Safe check: use base IElementHandler.PlatformView which returns null
+			// instead of ViewHandler<T>.PlatformView which throws
+			if (((IElementHandler)handler).PlatformView is null)
+			{
+				System.Diagnostics.Debug.WriteLine(
+					"[Maui.Nuke] Skipping MapSource - PlatformView is null (handler disconnected)");
+				return;
+			}
+
+			try
+			{
+				NukeImageHandler.MapSource(handler, view);
+			}
+			catch (InvalidOperationException ex) when (ex.Message.Contains("PlatformView cannot be null"))
+			{
+				// Race condition: PlatformView became null between our check and the actual access.
+				// This is expected during fast scrolling in CollectionViews, navigation transitions,
+				// tab switching in Shell, and CarPlay/background transitions.
+				System.Diagnostics.Debug.WriteLine(
+					$"[Maui.Nuke] PlatformView disconnected during MapSource (race condition, expected): {ex.Message}");
+			}
 		});
 		
 		builder.ConfigureImageSources(services =>

--- a/Maui.Nuke/NukeImageHandler.ios.cs
+++ b/Maui.Nuke/NukeImageHandler.ios.cs
@@ -1,4 +1,4 @@
-﻿#if IOS || MACCATALYST
+#if IOS || MACCATALYST
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using UIKit;
@@ -14,6 +14,30 @@ public class NukeImageHandler : ImageHandler
 {
 	private UIImage? _lastImage;
 
+	/// <summary>
+	/// Safely checks if the handler's native platform view is still connected.
+	/// 
+	/// IMPORTANT: ViewHandler&lt;T&gt;.PlatformView throws InvalidOperationException
+	/// when the native view is null (disconnected handler). The base IElementHandler.PlatformView
+	/// property returns null safely. We must use this safe path to avoid crashes during
+	/// async operations that complete after view disconnection.
+	/// 
+	/// See: https://github.com/dotnet/maui/issues/17165
+	///      https://github.com/dotnet/maui/issues/17569
+	///      https://github.com/dotnet/maui/issues/27194
+	/// </summary>
+	private static bool HasPlatformView(IElementHandler handler)
+	{
+		try
+		{
+			return ((IElementHandler)handler).PlatformView is not null;
+		}
+		catch (ObjectDisposedException)
+		{
+			return false;
+		}
+	}
+
 	public static new void MapSource(IImageHandler handler, Microsoft.Maui.IImage image)
 	{
 		_ = MapSourceAsync(handler, image);
@@ -21,24 +45,61 @@ public class NukeImageHandler : ImageHandler
 
 	public static new async Task MapSourceAsync(IImageHandler handler, Microsoft.Maui.IImage image)
 	{
-		await ImageHandler.MapSourceAsync(handler, image);
+		// Guard: ensure PlatformView is still connected before starting async work
+		if (!HasPlatformView(handler))
+			return;
 
-		// After the source has been loaded, ensure InvalidateMeasure is called
-		if (handler is NukeImageHandler nukeHandler && nukeHandler.PlatformView is { } imageView)
+		try
 		{
-			await MainThread.InvokeOnMainThreadAsync(() =>
+			await ImageHandler.MapSourceAsync(handler, image);
+		}
+		catch (InvalidOperationException ex) when (ex.Message.Contains("PlatformView cannot be null"))
+		{
+			// Race condition: handler was disconnected during async image load.
+			// This is expected during fast scrolling, navigation, or tab switching.
+			System.Diagnostics.Debug.WriteLine(
+				$"[Maui.Nuke] PlatformView disconnected during image source mapping (expected during recycling): {ex.Message}");
+			return;
+		}
+		catch (ObjectDisposedException)
+		{
+			// Native view was disposed during async operation
+			System.Diagnostics.Debug.WriteLine(
+				"[Maui.Nuke] PlatformView disposed during image source mapping");
+			return;
+		}
+
+		// After the source has been loaded, ensure InvalidateMeasure is called.
+		// Re-check PlatformView since async gap above could have allowed disconnection.
+		if (handler is NukeImageHandler nukeHandler && HasPlatformView(handler))
+		{
+			try
 			{
-				if (imageView.Image != null && !ReferenceEquals(imageView.Image, nukeHandler._lastImage))
+				var imageView = nukeHandler.PlatformView;
+				await MainThread.InvokeOnMainThreadAsync(() =>
 				{
-					nukeHandler._lastImage = imageView.Image;
-					// Call the extension method with both UIView and IView
-					if (image.Source is not IStreamImageSource)
+					if (imageView.Image != null && !ReferenceEquals(imageView.Image, nukeHandler._lastImage))
 					{
-						// If it's a StreamImageSource invalidate measure is already called by the maui image handler
-						imageView.InvalidateMeasure(image);
+						nukeHandler._lastImage = imageView.Image;
+						// If it's a StreamImageSource, InvalidateMeasure is already called by the MAUI image handler
+						if (image.Source is not IStreamImageSource)
+						{
+							imageView.InvalidateMeasure(image);
+						}
 					}
-				}
-			});
+				});
+			}
+			catch (InvalidOperationException ex) when (ex.Message.Contains("PlatformView cannot be null"))
+			{
+				// Handler disconnected between our check and access - this is fine
+				System.Diagnostics.Debug.WriteLine(
+					$"[Maui.Nuke] PlatformView disconnected during measure invalidation: {ex.Message}");
+			}
+			catch (ObjectDisposedException)
+			{
+				System.Diagnostics.Debug.WriteLine(
+					"[Maui.Nuke] PlatformView disposed during measure invalidation");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Guard against InvalidOperationException ('PlatformView cannot be null here') that occurs when async image loads complete after the handler has been disconnected. This is a known MAUI framework issue where ViewHandler<T>.PlatformView throws instead of returning null.

Common trigger scenarios:
- Fast scrolling in CollectionViews (cell recycling)
- Navigation (page popped while images loading)
- Tab switching in Shell
- CarPlay/background transitions

Changes:
- NukeImageHandler: Add HasPlatformView() helper using safe base IElementHandler.PlatformView check, wrap MapSourceAsync in try/catch, re-check before InvalidateMeasure access
- ImageSourcesMauiAppBuilderExtensions: Add defense-in-depth guard at mapper level before calling MapSource

Refs: dotnet/maui#17165, dotnet/maui#17569, dotnet/maui#27194
Fixes: #11